### PR TITLE
fix a problem of compiling zCore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "The x86_64 UEFI bootloader for rCore"
 
 [dependencies]
 uefi = "=0.4.6"
-uefi-services = { version = "0.2.4", optional = true }
+uefi-services = { version = "=0.2.4", optional = true }
 log = "0.4"
 xmas-elf = "0.7"
 x86_64 = "0.11"


### PR DESCRIPTION
New version of `uefi-services` depends on `uefi 5.0`, but error will occur when compiling `uefi 5.0` for zCore